### PR TITLE
Demo missing template scanner imaging modality fix (#464)

### DIFF
--- a/examples/src/generate_image.par
+++ b/examples/src/generate_image.par
@@ -1,4 +1,14 @@
 generate_image Parameters :=
+
+; optional: values: PET|nucmed *defaults to PET for backwards compatibility)
+imaging modality:=PET
+; optional patient position keywords (defaulting to "unknown")
+; orientation: allowed values: head_in|feet_in|other|unknown
+patient orientation := head_in
+; rotation: allowed values: prone|supine|other|unknown
+patient rotation :=  supine
+image duration (sec) := 1 ; defaults to -1 (i.e. unknown)
+
 output filename:=image
 X output image size (in pixels):=56
 Y output image size (in pixels):=56

--- a/examples/src/small.hs
+++ b/examples/src/small.hs
@@ -1,6 +1,14 @@
 !INTERFILE  :=
 name of data file := small.s
+!imaging modality := PET
 originating system := RATPET
+; optional: values: PET|nucmed *defaults to PET for backwards compatibility)
+imaging modality:=PET
+; optional patient position keywords (defaulting to "unknown")
+; orientation: allowed values: head_in|feet_in|other|unknown
+patient orientation := head_in
+; rotation: allowed values: prone|supine|other|unknown
+patient rotation :=  supine
 !GENERAL DATA :=
 !GENERAL IMAGE DATA :=
 !type of data := PET


### PR DESCRIPTION
Fix to Demo's template and generate_image.par file: include imaging modality, patient orientation etc, and image duration in generate_image.par.

Fixes #463