### PR TITLE
Add method stir.ToPriorWithParabolicSurrogate() to python.

### DIFF
--- a/src/swig/stir.i
+++ b/src/swig/stir.i
@@ -1656,6 +1656,13 @@ stir::RegisteredParsingObject< stir::LogcoshPrior<elemT>,
         stir::PriorWithParabolicSurrogate<TargetT  > >;
 %template (LogcoshPrior3DFloat) stir::LogcoshPrior<elemT>;
 
+// Allows for access to parabolic surrogate type prior methods ( THIS IS A TEMPORARY FIX )
+%inline %{template <class T> stir::PriorWithParabolicSurrogate<T> * ToPriorWithParabolicSurrogate(stir::GeneralisedPrior<T> *b) {
+  return dynamic_cast<stir::PriorWithParabolicSurrogate<T>*>(b);
+}
+%}
+%template(ToPriorWithParabolicSurrogate) ToPriorWithParabolicSurrogate<TargetT >;
+
 %template (Reconstruction3DFloat) stir::Reconstruction<TargetT >;
 //%template () stir::Reconstruction<TargetT >;
 %template (IterativeReconstruction3DFloat) stir::IterativeReconstruction<TargetT >;


### PR DESCRIPTION
Input is a GeneralisedPrior. This will give access to methods such as `parabolic_surrogate_curvature` and `add_multiplication_with_approximate_Hessian` from the objective function object.

This would be a temporary fix for part of https://github.com/UCL/STIR/issues/707

This doesnt expose non-parabolic surrogate type function methods (e.g. `get_gamma()` and `get_epsilon()` in the RDP)