### PR TITLE
parabolic_surrogate_curvature_times_input methods for QP and Logcosh

### DIFF
--- a/src/include/stir/recon_buildblock/LogcoshPrior.h
+++ b/src/include/stir/recon_buildblock/LogcoshPrior.h
@@ -137,6 +137,11 @@ public:
                          const BasicCoordinate<3,int>& coords,
                          const DiscretisedDensity<3,elemT> &current_image_estimate);
 
+    //! compute the parabolic surrogate curvature for the prior of the current image estimate and multiply by input image
+    void parabolic_surrogate_curvature_times_input(DiscretisedDensity<3,elemT>& output,
+                                                   const DiscretisedDensity<3,elemT> &current_image_estimate,
+                                                   const DiscretisedDensity<3,elemT> &input_image);
+
     //! Compute the multiplication of the hessian of the prior multiplied by the input.
     virtual Succeeded accumulate_Hessian_times_input(DiscretisedDensity<3,elemT>& output,
                                                      const DiscretisedDensity<3,elemT>& current_estimate,

--- a/src/include/stir/recon_buildblock/PriorWithParabolicSurrogate.h
+++ b/src/include/stir/recon_buildblock/PriorWithParabolicSurrogate.h
@@ -55,7 +55,19 @@ public:
     parabolic_surrogate_curvature(TargetT& parabolic_surrogate_curvature, 
 				  const TargetT &current_estimate) = 0;
 
-  //! A function that allows skipping some computations if the curvature is independent of the \c current_estimate
+  //! This will calculate the parabolic surrogate curvature of the current image estimate multiplied by the input image
+  /*!
+    Function is comparable to that of accumulate_Hessian_times_input() but instead of the Hessian, we use the parabolic
+    surrogate curvature.
+    For each voxel (f_{j}) of the image, this method computes
+    \beta \sum_{i\in J} d_{i,j} f_{i}
+    where J is the neighbourhood about voxel j and d_{i,j} is the surrogate function between j and i.
+   */
+  virtual void parabolic_surrogate_curvature_times_input(TargetT& output,
+                                                         const TargetT& current_image_estimate,
+                                                         const TargetT& input_image) = 0;
+
+    //! A function that allows skipping some computations if the curvature is independent of the \c current_estimate
   /*! Defaults to return \c true, but can be overloaded by the derived class.
    */
   virtual bool

--- a/src/include/stir/recon_buildblock/QuadraticPrior.h
+++ b/src/include/stir/recon_buildblock/QuadraticPrior.h
@@ -129,7 +129,13 @@ class QuadraticPrior:  public
                 const BasicCoordinate<3,int>& coords,
                 const DiscretisedDensity<3,elemT> &current_image_estimate);
 
-  //! Call accumulate_Hessian_times_input
+  //! compute the parabolic surrogate curvature for the prior of the current image estimate and multiply by input image
+  void parabolic_surrogate_curvature_times_input(DiscretisedDensity<3,elemT>& output,
+                                                 const DiscretisedDensity<3,elemT> &current_image_estimate,
+                                                 const DiscretisedDensity<3,elemT> &input_image);
+
+
+    //! Call accumulate_Hessian_times_input
   virtual Succeeded 
     add_multiplication_with_approximate_Hessian(DiscretisedDensity<3,elemT>& output,
                                                 const DiscretisedDensity<3,elemT>& input) const;

--- a/src/recon_buildblock/QuadraticPrior.cxx
+++ b/src/recon_buildblock/QuadraticPrior.cxx
@@ -723,7 +723,6 @@ parabolic_surrogate_curvature_times_input(DiscretisedDensity<3,elemT>& output,
           for (int dy=min_dy;dy<=max_dy;++dy)
             for (int dx=min_dx;dx<=max_dx;++dx)
             {
-              elemT voxel_diff= current_image_estimate[z][y][x] - current_image_estimate[z+dz][y+dy][x+dx];
               // The parabolic surrogate curvature of the QP is 1
               elemT current = weights[dz][dy][dx] * input_image[z+dz][y+dy][x+dx];
 

--- a/src/recon_buildblock/QuadraticPrior.cxx
+++ b/src/recon_buildblock/QuadraticPrior.cxx
@@ -667,6 +667,79 @@ accumulate_Hessian_times_input(DiscretisedDensity<3,elemT>& output,
   return Succeeded::yes;
 }
 
+template <typename elemT>
+void
+QuadraticPrior<elemT>::
+parabolic_surrogate_curvature_times_input(DiscretisedDensity<3,elemT>& output,
+                                          const DiscretisedDensity<3,elemT> &current_image_estimate,
+                                          const DiscretisedDensity<3,elemT> &input_image)
+{
+  assert( output.has_same_characteristics(input));
+  assert( output.has_same_characteristics(current_image_estimate));
+  output.fill(0.f);
+  if (this->penalisation_factor==0)
+  {
+    return;
+  }
+
+  DiscretisedDensityOnCartesianGrid<3,elemT>& output_cast =
+          dynamic_cast<DiscretisedDensityOnCartesianGrid<3,elemT> &>(output);
+
+  if (weights.get_length() ==0)
+  {
+    compute_weights(weights, output_cast.get_grid_spacing(), this->only_2D);
+  }
+
+  const bool do_kappa = !is_null_ptr(kappa_ptr);
+
+  if (do_kappa && !kappa_ptr->has_same_characteristics(input_image))
+    error("LogcoshPrior: kappa image has not the same index range as the reconstructed image\n");
+
+  const int min_z = output.get_min_index();
+  const int max_z = output.get_max_index();
+  for (int z=min_z; z<=max_z; z++)
+  {
+    const int min_dz = max(weights.get_min_index(), min_z-z);
+    const int max_dz = min(weights.get_max_index(), max_z-z);
+
+    const int min_y = output[z].get_min_index();
+    const int max_y = output[z].get_max_index();
+
+    for (int y=min_y;y<= max_y;y++)
+    {
+      const int min_dy = max(weights[0].get_min_index(), min_y-y);
+      const int max_dy = min(weights[0].get_max_index(), max_y-y);
+
+      const int min_x = output[z][y].get_min_index();
+      const int max_x = output[z][y].get_max_index();
+
+      for (int x=min_x;x<= max_x;x++)
+      {
+        const int min_dx = max(weights[0][0].get_min_index(), min_x-x);
+        const int max_dx = min(weights[0][0].get_max_index(), max_x-x);
+
+        elemT result = 0;
+        for (int dz=min_dz;dz<=max_dz;++dz)
+          for (int dy=min_dy;dy<=max_dy;++dy)
+            for (int dx=min_dx;dx<=max_dx;++dx)
+            {
+              elemT voxel_diff= current_image_estimate[z][y][x] - current_image_estimate[z+dz][y+dy][x+dx];
+              // The parabolic surrogate curvature of the QP is 1
+              elemT current = weights[dz][dy][dx] * input_image[z+dz][y+dy][x+dx];
+
+              if (do_kappa)
+                current *= (*kappa_ptr)[z][y][x] * (*kappa_ptr)[z+dz][y+dy][x+dx];
+
+              result += current;
+            }
+
+        output[z][y][x] += result * this->penalisation_factor;
+      }
+    }
+  }
+}
+
+
 #  ifdef _MSC_VER
 // prevent warning message on reinstantiation, 
 // note that we get a linking error if we don't have the explicit instantiation below


### PR DESCRIPTION
Adds the `parabolic_surrogate_curvature_times_input` methods for the prior. This is about the same methodology as the `accumulate_Hessian_times_input` methods. 

Need to check that the function is correct for both QP and logcosh prior